### PR TITLE
UR enable to customize dsl files to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ The project is intended to be used locally while authoring diagrams and in build
 $ docker run --rm -it -v $(pwd):/docs extenda/structurizr-to-png
 ```
 
-The convention is to generate diagrams to an `images/` directory inside the working directory. The default working directory used in the container is `/docs`. The above command will render all `*.dsl` files in the current working directory.
+The convention is to generate diagrams to an `images/` directory inside the working directory. The default working directory used in the container is `/docs`. The above command will render all `*.dsl` files in the current working directory and it's subdirectories.
+
+To render particular dsl files, use the `--path` option (glob is supported). Relative paths are treated from DSL file directory.
+
+```bash
+$ docker run --rm -it -v $(pwd):/docs extenda/structurizr-to-png --path workspace.ecd.dsl
+```
 
 To change the default output location, use the `--output` option. If specified as a relative path, it is resolved from DSL file directory.
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,10 @@ process.once('SIGINT', () => {
 
 (async () => {
   // Find all dsl files from the working directory.
-  const dslFiles = glob.sync(['**/*.dsl', '!**/node_modules']);
+  const dslFiles = glob.sync([opts.path, '!**/node_modules']);
 
   if (dslFiles.length === 0) {
-    console.log(chalk.red('No DSL files found matching **/*.dsl'));
+    console.log(chalk.red('No DSL files found matching *.dsl'));
     process.exit(0);
   }
 

--- a/src/opts.js
+++ b/src/opts.js
@@ -14,10 +14,16 @@ const argv = yargs(hideBin(process.argv))
     type: 'boolean',
     default: false,
     description: 'Watch for changed DSL files.'
+  }).option('path', {
+    alias: 'p',
+    type: 'string',
+    default: '**/*.dsl',
+    description: 'Path to workspaces to render. Glob is supported'
   }).argv;
 
 module.exports = {
   workDir: path.resolve(__dirname, '..', '.work'),
   outputDir: argv.output,
   watch: argv.watch,
+  path: argv.path
 }


### PR DESCRIPTION
We have a lot of dsl files in working directory and subdirectories but need to render only a few of root workspaces. Option `path` allows to overwrite default usage of "render all dsl files" while keeping backwards compatibility with existing behavior.