### PR TITLE
feat: Use PlantUML as a server to speed up PNG creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,11 +79,18 @@
       "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.23.0.tgz",
+      "integrity": "sha512-NmvAE4i0YAv5cKq8zlDoPd1VLKAqX5oLuZKs8xkJa4qi6RGn0uhCYFjWtHHC9EM/MwOwYWOs53W+V0aqEXq1sg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.4"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.4",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+          "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+        }
       }
     },
     "backo2": {
@@ -816,6 +823,14 @@
         "yargs": "16.2.0"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -989,6 +1004,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+    },
+    "plantuml-encoder": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.4.0.tgz",
+      "integrity": "sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g=="
     },
     "portscanner": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   "homepage": "https://github.com/extenda/structurizr-to-png#readme",
   "license": "MIT",
   "dependencies": {
+    "axios": "^0.23.0",
     "browser-sync": "^2.26.14",
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "fast-glob": "^3.2.5",
+    "plantuml-encoder": "^1.4.0",
     "yargs": "^16.2.0"
   }
 }

--- a/src/dsl-to-png.js
+++ b/src/dsl-to-png.js
@@ -29,20 +29,18 @@ const singleDslToPng = async (dslFile) => {
 };
 
 const allDslToPng = async (dslFiles) => {
-  let promises = [];
   const visitedDirs = new Set();
-  dslFiles.forEach(dslFile => {
-    promises.push(dslToPuml(createDslEntry(dslFile))
+  const promises = dslFiles.map(dslFile => dslToPuml(createDslEntry(dslFile))
       .then((dslEntry) => {
         // PUML files are processed per directory so we
         // only process each working directory once.
         if (!visitedDirs.has(dslEntry.uniqueWorkDir)) {
           visitedDirs.add(dslEntry.uniqueWorkDir);
-          return processPuml(dslEntry).then(e => plantUml(e, true));
+          return processPuml(dslEntry)
+              .then(e => plantUml(e, true));
         }
         return dslEntry;
       }));
-  });
   return Promise.all(promises);
 };
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,17 @@
+const chalk = require('chalk');
+
+const LOG_NAME = `[${chalk.blue('dsl2png')}]`;
+
+const format = (msg, dslFile = '') => {
+  if (dslFile) {
+    return `${LOG_NAME} ${chalk.green(dslFile)} - ${msg}`;
+  }
+  return `${LOG_NAME} ${msg}`;
+};
+
+module.exports = {
+  error: (msg) => console.error(format(chalk.red(msg))),
+  info: (msg) => console.log(format(msg)),
+  logDsl: (dslFile, msg) => console.log(format(msg, dslFile)),
+  raw: (msg) => console.log(msg),
+};

--- a/src/plantuml.js
+++ b/src/plantuml.js
@@ -1,0 +1,53 @@
+const chalk = require('chalk');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const axios = require('axios');
+const plantUmlEncoder = require('plantuml-encoder');
+const log = require('./logger');
+
+const libDir = path.resolve(__dirname, '..', 'lib');
+
+let resolveServerReady;
+
+const serverReady = new Promise((resolve, reject) => {
+  resolveServerReady = resolve;
+});
+
+const startServer = () => {
+  log.info('Start PlantUML server');
+  const server = spawn('java', ['-jar', path.join(libDir, 'plantuml.jar'), '-picoweb:8888']);
+  server.on('error', (err) => {
+    log.error(`PlantUML error.\n${err.message}`);
+  });
+
+  server.stderr.once('data', () => {
+    log.info('PlantUML server listening on port 8888');
+    resolveServerReady();
+  })
+
+  server.once('close', () => {
+    log.info('Close PlantUML server');
+  });
+
+  return () => server.kill('SIGKILL');
+};
+
+const renderPng = async (pumlFile) => {
+  // Wait for PlantUML to be ready for requests.
+  await serverReady;
+
+  const data = plantUmlEncoder.encode(fs.readFileSync(pumlFile, 'utf8'));
+  return axios.get(
+    `http://127.0.0.1:8888/plantuml/png/${data}`,
+    { responseType: 'arraybuffer' },
+    ).then((response) => ({
+      imageName: path.basename(pumlFile, '.puml') + '.png',
+      data: response.data
+    }));
+}
+
+module.exports = {
+  startServer,
+  renderPng,
+}

--- a/src/watch.js
+++ b/src/watch.js
@@ -5,6 +5,7 @@ const fg = require('fast-glob');
 const bs = require('browser-sync').create();
 const { createDslEntry, singleDslToPng } = require('./dsl-to-png');
 const { workDir, outputDir } = require('./opts.js');
+const log = require('./logger');
 
 const createIndexPage = (images, filename) => {
   const imgTags = [];
@@ -33,10 +34,8 @@ const createWebroot = () => {
 
 const changeHandler = (event, filename) => {
   if (filename && event === 'change') {
-    // TODO Log something
-    console.log('Process', event, filename);
     singleDslToPng(filename).catch((err) => {
-      console.error(err.message);
+      log.error(err.message);
     })
   }
 };
@@ -48,7 +47,7 @@ const watch = (dslFiles) => {
   const watcher = chokidar.watch(dslFiles, { persistent: true });
   watcher.on('change', (path) => {
     singleDslToPng(path).catch((err) => {
-      console.error(err.message);
+      log.error(err.message);
     });
   });
 


### PR DESCRIPTION
PlantUML is now started with the PicoWeb server and reused for all image rendering. This will speed up the process when multiple PUML files are processed and when `--watch` is used.