### PR TITLE
fix: Use readFile as readFileSync intermittently returned empty data

### DIFF
--- a/install-tools.sh
+++ b/install-tools.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -e
 SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+rm -rf "$SCRIPT_PATH/lib"
 mkdir -p "$SCRIPT_PATH/lib"
 
-plantUmlVersion="1.2021.9"
+plantUmlVersion="1.2021.12"
 curl -sS "https://repo.maven.apache.org/maven2/net/sourceforge/plantuml/plantuml/$plantUmlVersion/plantuml-${plantUmlVersion}.jar" -o "$SCRIPT_PATH/lib/plantuml.jar"
 
 structurizrVersion="1.15.0"

--- a/src/plantuml.js
+++ b/src/plantuml.js
@@ -1,7 +1,7 @@
 const chalk = require('chalk');
 const { spawn } = require('child_process');
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs').promises;
 const axios = require('axios');
 const plantUmlEncoder = require('plantuml-encoder');
 const log = require('./logger');
@@ -37,14 +37,15 @@ const renderPng = async (pumlFile) => {
   // Wait for PlantUML to be ready for requests.
   await serverReady;
 
-  const data = plantUmlEncoder.encode(fs.readFileSync(pumlFile, 'utf8'));
-  return axios.get(
+  return fs.readFile(pumlFile, 'utf8')
+    .then(plantUmlEncoder.encode)
+    .then((data) => axios.get(
     `http://127.0.0.1:8888/plantuml/png/${data}`,
     { responseType: 'arraybuffer' },
     ).then((response) => ({
       imageName: path.basename(pumlFile, '.puml') + '.png',
       data: response.data
-    }));
+    })));
 }
 
 module.exports = {


### PR DESCRIPTION
This change is an attempt to close the intermittent (but common) glitch with empty PUML files sent to the plantuml server.