### PR TITLE
feat: Add log-level parameter

### DIFF
--- a/src/main/java/com/extendaretail/dsl2png/cli/Arguments.java
+++ b/src/main/java/com/extendaretail/dsl2png/cli/Arguments.java
@@ -9,6 +9,9 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 public class Arguments {
 
@@ -90,6 +93,13 @@ public class Arguments {
             .type(Renderer.class)
             .desc("The name of the diagram renderer to use.")
             .build());
+    opts.addOption(
+        Option.builder()
+            .longOpt("log-level")
+            .hasArg()
+            .type(Level.class)
+            .desc("Log verbosity level")
+            .build());
     opts.addOption(Option.builder().longOpt("help").build());
 
     Arguments arguments = new Arguments();
@@ -102,6 +112,12 @@ public class Arguments {
           Renderer.valueOf(cmd.getOptionValue("render-with", Renderer.c4plantuml.name()));
       if (cmd.hasOption("help")) {
         throw new HelpException(help(opts), 0);
+      }
+      Level logLevel = Level.valueOf(cmd.getOptionValue("log-level", Level.INFO.name()));
+      Logger logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+      if (logger instanceof ch.qos.logback.classic.Logger logbackLogger
+          && (logbackLogger.getLevel().toInt() != logLevel.toInt())) {
+        logbackLogger.setLevel(ch.qos.logback.classic.Level.valueOf(logLevel.name()));
       }
     } catch (ParseException e) {
       throw new HelpException(help(opts), 1);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,10 +5,9 @@
       <pattern>[%highlight(%level)] %cyan(%X{dsl:-*}) %msg%n%ex{SHORT}</pattern>
     </encoder>
   </appender>
-  <logger name="com.extendaretail" level="info"/>
-  <logger name="guru.nidi.graphviz" level="error"/>
-  <logger name="com.structurizr.dsl.AbstractViewParser" level="error"/>
-  <root level="info">
+  <logger name="guru.nidi.graphviz" level="ERROR"/>
+  <logger name="com.structurizr.dsl.AbstractViewParser" level="ERROR"/>
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
Add new `log-level` parameter to control the root level log verbosity.

```
./dsl2png.sh --log-level=DEBUG
```

The default log level is `INFO`.

Closes #48 